### PR TITLE
Force Image to store standard data

### DIFF
--- a/gp_retouch/image/image.py
+++ b/gp_retouch/image/image.py
@@ -4,6 +4,9 @@ from typing import Dict, Optional, Union
 import matplotlib.pyplot as plt
 import numpy as np
 
+MIN_PIXEL_VALUE = 0
+MAX_PIXEL_VALUE = 255
+PIXEL_DATA_TYPE = float
 
 class Image:
     """Represents an image and provides the user basic manipulation methods.
@@ -23,8 +26,20 @@ class Image:
             data (np.ndarray): the image's actual data.
             metadata (Optional[Dict], optional): any extra info about the data.
         """
-        self.data = data.astype(float)
+        self._data = None
+        self.data = data
         self.metadata = metadata or {}
+
+    @property
+    def data(self) -> np.ndarray:  # noqa: D102
+        return self._data
+
+    @data.setter
+    def data(self, value: np.ndarray):
+        """Set the image data, ensuring values are between 0 and 255."""
+        if not np.all(np.isnan(value) | ((MIN_PIXEL_VALUE <= value) & (value <= MAX_PIXEL_VALUE))):
+            raise ValueError("All values in the image data must be between 0 and 255, or NaNs.")
+        self._data = value.astype(PIXEL_DATA_TYPE)
 
     @property
     def is_grayscale(self) -> bool:  # noqa: D102

--- a/gp_retouch/image/image_processor.py
+++ b/gp_retouch/image/image_processor.py
@@ -85,9 +85,7 @@ class ImageProcessor:
         std_dev = np.sqrt(variance)
         noise = np.random.normal(mean, std_dev, image.data.shape)
         # Add noise to the image
-        image.data = image.data + noise
-        # Ensure it stays bounded
-        image.data = np.clip(image.data, 0, 255)
+        image.data = ImageProcessor._filter_values(image.data + noise)
         return image
     
     @staticmethod
@@ -121,8 +119,7 @@ class ImageProcessor:
             raise ValueError("Variance must be non-negative.")
 
         noise = np.random.normal(0, np.sqrt(variance), image.data.shape)
-        image.data = image.data + image.data * noise
-        image.data = np.clip(image.data, 0, 255)
+        image.data = ImageProcessor._filter_values(image.data + image.data * noise)
         return image
 
     @staticmethod
@@ -132,8 +129,7 @@ class ImageProcessor:
             raise ValueError("Intensity must be non-negative.")
 
         noise = np.random.uniform(-intensity, intensity, image.data.shape)
-        image.data = image.data + noise
-        image.data = np.clip(image.data, 0, 255)
+        image.data = ImageProcessor._filter_values(image.data + noise)
         return image
 
     @staticmethod
@@ -219,3 +215,10 @@ class ImageProcessor:
         image.data[mask] = np.nan
 
         return image
+
+    @staticmethod
+    def _filter_values(data: np.ndarray) -> np.ndarray:
+        """."""
+        min_pixel_value = 0
+        max_pixel_value = 255
+        return np.clip(data, min_pixel_value, max_pixel_value)

--- a/gp_retouch/retoucher.py
+++ b/gp_retouch/retoucher.py
@@ -99,6 +99,7 @@ class Retoucher:
             else:
                 reconstructed_data = channel_data
 
+        reconstructed_data = self._filter_predictions(reconstructed_data)
         return Image(reconstructed_data)
     
     def denoise_image(self, image: Image, factor: float) -> Image:
@@ -147,6 +148,7 @@ class Retoucher:
             else:
                 denoised_data = denoised_channel
 
+        denoised_data = self._filter_predictions(denoised_data)
         return Image(denoised_data)
 
     @staticmethod
@@ -163,7 +165,7 @@ class Retoucher:
         pass
 
     @staticmethod
-    def _get_non_nan_data(data):
+    def _get_non_nan_data(data: np.ndarray):
         """Get the non-NaN coordinates and values from the image data.
 
         Args:
@@ -177,7 +179,7 @@ class Retoucher:
         return coords, values
 
     @staticmethod
-    def _get_grid_coords(data):
+    def _get_grid_coords(data: np.ndarray):
         """Get the grid coordinates and their normalized version.
 
         Args:
@@ -192,3 +194,10 @@ class Retoucher:
         grid_coords = np.c_[grid_x.ravel(), grid_y.ravel()]
         grid_coords_normalized = grid_coords / np.array([data.shape[0], data.shape[1]])
         return grid_coords, grid_coords_normalized
+
+    @staticmethod
+    def _filter_predictions(data: np.ndarray) -> np.ndarray:
+        """."""
+        min_pixel_value = 0
+        max_pixel_value = 255
+        return np.clip(data, min_pixel_value, max_pixel_value)


### PR DESCRIPTION
This PR is essentially me trying to make the Image class more robust: image.data now is guaranteed to have data of a specific format (between 0 and 255 and/or NaNs).

The other modules were adapted to cope with this change.